### PR TITLE
Close objects with order

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -10,8 +10,9 @@ import (
 // Then you can add definitions with the Add method,
 // and finally build the Container with the Build method.
 type Builder struct {
-	definitions DefMap
-	scopes      ScopeList
+	definitions     DefMap
+	definitionOrder []string
+	scopes          ScopeList
 }
 
 // NewBuilder is the only way to create a working Builder.
@@ -30,8 +31,9 @@ func NewBuilder(scopes ...string) (*Builder, error) {
 	}
 
 	return &Builder{
-		definitions: DefMap{},
-		scopes:      scopes,
+		definitions:     DefMap{},
+		definitionOrder: []string{},
+		scopes:          scopes,
 	}, nil
 }
 
@@ -98,6 +100,7 @@ func (b *Builder) add(def Def) error {
 	}
 
 	b.definitions[def.Name] = def
+	b.definitionOrder = append(b.definitionOrder, def.Name)
 
 	return nil
 }
@@ -132,12 +135,13 @@ func (b *Builder) Build() Container {
 
 	return &container{
 		containerCore: &containerCore{
-			scopes:      b.scopes,
-			scope:       b.scopes[0],
-			definitions: defs,
-			parent:      nil,
-			children:    map[*containerCore]struct{}{},
-			objects:     map[string]interface{}{},
+			scopes:          b.scopes,
+			scope:           b.scopes[0],
+			definitions:     defs,
+			definitionOrder: b.definitionOrder,
+			parent:          nil,
+			children:        map[*containerCore]struct{}{},
+			objects:         map[string]interface{}{},
 		},
 	}
 }

--- a/containerCore.go
+++ b/containerCore.go
@@ -11,6 +11,7 @@ type containerCore struct {
 	scope           string
 	scopes          ScopeList
 	definitions     DefMap
+	definitionOrder []string
 	parent          *containerCore
 	children        map[*containerCore]struct{}
 	unscopedChild   *containerCore

--- a/containerLineage.go
+++ b/containerLineage.go
@@ -52,13 +52,14 @@ func (l *containerLineage) createChild(ctn *container) (*container, error) {
 
 	return &container{
 		containerCore: &containerCore{
-			scope:         subscopes[0],
-			scopes:        ctn.scopes,
-			definitions:   ctn.definitions,
-			parent:        ctn.containerCore,
-			children:      map[*containerCore]struct{}{},
-			unscopedChild: nil,
-			objects:       map[string]interface{}{},
+			scope:           subscopes[0],
+			scopes:          ctn.scopes,
+			definitions:     ctn.definitions,
+			definitionOrder: ctn.definitionOrder,
+			parent:          ctn.containerCore,
+			children:        map[*containerCore]struct{}{},
+			unscopedChild:   nil,
+			objects:         map[string]interface{}{},
 		},
 	}, nil
 }

--- a/containerSlayer.go
+++ b/containerSlayer.go
@@ -32,8 +32,13 @@ func (s *containerSlayer) DeleteWithSubContainers(ctn *containerCore) error {
 		parent:          ctn.parent,
 		objects:         ctn.objects,
 	}
-	ctn.closed = true
 	ctn.m.Unlock()
+
+	defer func() {
+		ctn.m.Lock()
+		ctn.closed = true
+		ctn.m.Unlock()
+	}()
 
 	return s.deleteClone(ctn, clone)
 }


### PR DESCRIPTION
Now, objects are ordered. If you want an object B been closed after object A, just define B at behind of A in the Def array.
eg.
```go
[]Def{
		{
			Name:  "A",
			Scope: App,
		},
		{
			Name:  "B",
			Scope: App,
		},
	}
```
B will be closed after A, and you can use `ctn.Get("A")` to get A instance in B's **`Close` function**.