### PR TITLE
Fix Close call on buildingChan

### DIFF
--- a/containerSlayer.go
+++ b/containerSlayer.go
@@ -85,6 +85,10 @@ func (s *containerSlayer) closeObject(obj interface{}, def Def) (err error) {
 		}
 	}()
 
+	if _, isBuilding := obj.(buildingChan); isBuilding {
+		return nil
+	}
+
 	if def.Close != nil {
 		err = def.Close(obj)
 	}


### PR DESCRIPTION
The Close function could be called with a buildingChan. It could happen if the Build function was taking too long and if the container was suddenly deleted by another goroutine.