### PR TITLE
Fix the object closing order

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -132,12 +132,13 @@ func (b *Builder) Build() Container {
 
 	return &container{
 		containerCore: &containerCore{
-			scopes:      b.scopes,
-			scope:       b.scopes[0],
-			definitions: defs,
-			parent:      nil,
-			children:    map[*containerCore]struct{}{},
-			objects:     map[string]interface{}{},
+			scopes:       b.scopes,
+			scope:        b.scopes[0],
+			definitions:  defs,
+			parent:       nil,
+			children:     map[*containerCore]struct{}{},
+			objects:      map[string]interface{}{},
+			dependencies: newGraph(),
 		},
 	}
 }

--- a/containerCore.go
+++ b/containerCore.go
@@ -16,6 +16,7 @@ type containerCore struct {
 	unscopedChild   *containerCore
 	objects         map[string]interface{}
 	deleteIfNoChild bool
+	dependencies    *graph
 }
 
 func (ctn *containerCore) Definitions() map[string]Def {

--- a/containerGetter.go
+++ b/containerGetter.go
@@ -74,6 +74,8 @@ func (g *containerGetter) getInThisContainer(ctn *container, def Def) (interface
 		return nil, fmt.Errorf("could not get `%s` because the container has been deleted", def.Name)
 	}
 
+	g.addDependencyToGraph(ctn, def.Name)
+
 	obj, ok := ctn.objects[def.Name]
 	if !ok {
 		// the object need to be created
@@ -96,6 +98,14 @@ func (g *containerGetter) getInThisContainer(ctn *container, def Def) (interface
 	<-c
 
 	return g.getInThisContainer(ctn, def)
+}
+
+func (g *containerGetter) addDependencyToGraph(ctn *container, defName string) {
+	if last, ok := ctn.builtList.LastElement(); ok {
+		ctn.dependencies.AddEdge(last, defName)
+		return
+	}
+	ctn.dependencies.AddVertex(defName)
 }
 
 func (g *containerGetter) buildInThisContainer(ctn *container, def Def, c buildingChan) (interface{}, error) {

--- a/containerLineage.go
+++ b/containerLineage.go
@@ -59,6 +59,7 @@ func (l *containerLineage) createChild(ctn *container) (*container, error) {
 			children:      map[*containerCore]struct{}{},
 			unscopedChild: nil,
 			objects:       map[string]interface{}{},
+			dependencies:  newGraph(),
 		},
 	}, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -9,36 +9,157 @@ import (
 
 // builtList is used to store the objects
 // that a container has already built.
-// The key is the name of the object,
-// and the value is the number of elements
-// in the map when the element is inserted.
-type builtList map[string]int
+type builtList struct {
+	// last is the name of the last inserted element.
+	last string
+	// elements is used to store the inserted elements.
+	// The key is the name of the element,
+	// and the value is the number of elements
+	// in the map when the element is inserted.
+	elements map[string]int
+}
 
 // Add adds an element in the map.
 func (l builtList) Add(name string) builtList {
-	if l == nil {
-		return builtList{name: 0}
+	newL := builtList{
+		last:     name,
+		elements: map[string]int{},
 	}
-	l[name] = len(l)
-	return l
+
+	for k, v := range l.elements {
+		newL.elements[k] = v
+	}
+
+	newL.elements[name] = len(newL.elements)
+
+	return newL
 }
 
-// Has checks if the map contains the given element.
+// Has checks if the builtList contains the given element.
 func (l builtList) Has(name string) bool {
-	_, ok := l[name]
+	_, ok := l.elements[name]
 	return ok
 }
 
 // OrderedList returns the list of elements in the order
 // they were inserted.
 func (l builtList) OrderedList() []string {
-	s := make([]string, len(l))
+	s := make([]string, len(l.elements))
 
-	for name, i := range l {
+	for name, i := range l.elements {
 		s[i] = name
 	}
 
 	return s
+}
+
+// LastElement returns the last inserted element.
+func (l builtList) LastElement() (string, bool) {
+	if len(l.elements) > 0 {
+		return l.last, true
+	}
+	return "", false
+}
+
+// graph is a Directed Acyclic Graph.
+// It is used to store the dependencies inside a container.
+// These dependencies are then used to determine the order
+// that should be used to close the objects.
+type graph struct {
+	// names contains the keys of the "edges" field.
+	// It allows the vertices to be sorted.
+	// It makes the structure deterministic.
+	names []string
+	// vertices ordered by name.
+	vertices map[string]*graphVertex
+}
+
+// graphVertex contains the vertex data.
+type graphVertex struct {
+	// numIn in the number of incoming edges.
+	numIn int
+	// numInTmp is used by the TopologicalOrdering to avoid messing with numIn
+	numInTmp int
+	// out contains the name the outgoing edges.
+	out []string
+	// outMap is the same as "out", but in a map
+	// to quickly check if a vertex is in the outgoing edges.
+	outMap map[string]struct{}
+}
+
+// newGraph creates a new graph.
+func newGraph() *graph {
+	return &graph{
+		names:    []string{},
+		vertices: map[string]*graphVertex{},
+	}
+}
+
+// AddVertex adds a vertex to the graph.
+func (g *graph) AddVertex(v string) {
+	_, ok := g.vertices[v]
+	if ok {
+		return
+	}
+
+	g.names = append(g.names, v)
+
+	g.vertices[v] = &graphVertex{
+		numIn:  0,
+		out:    []string{},
+		outMap: map[string]struct{}{},
+	}
+}
+
+// AddEdge adds an edge to the graph.
+func (g *graph) AddEdge(from, to string) {
+	g.AddVertex(from)
+	g.AddVertex(to)
+
+	// check if the edge is aleady registered
+	if _, ok := g.vertices[from].outMap[to]; ok {
+		return
+	}
+
+	// update the vertices
+	g.vertices[from].out = append(g.vertices[from].out, to)
+	g.vertices[from].outMap[to] = struct{}{}
+	g.vertices[to].numIn++
+}
+
+// TopologicalOrdering returns a valid topological sort.
+// It implements Kahn's algorithm.
+// If there is a cycle in the graph, an error is returned.
+// The list of vertices is also returned even if it is not ordered.
+func (g *graph) TopologicalOrdering() ([]string, error) {
+	l := []string{}
+	q := []string{}
+
+	for _, v := range g.names {
+		if g.vertices[v].numIn == 0 {
+			q = append(q, v)
+		}
+		g.vertices[v].numInTmp = g.vertices[v].numIn
+	}
+
+	for len(q) > 0 {
+		n := q[len(q)-1]
+		q = q[:len(q)-1]
+		l = append(l, n)
+
+		for _, m := range g.vertices[n].out {
+			g.vertices[m].numInTmp--
+			if g.vertices[m].numInTmp == 0 {
+				q = append(q, m)
+			}
+		}
+	}
+
+	if len(l) != len(g.names) {
+		return append([]string{}, g.names...), errors.New("a cycle has been found in the dependencies")
+	}
+
+	return l, nil
 }
 
 // multiErrBuilder can accumulate errors.

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,18 +10,126 @@ import (
 func TestBuiltList(t *testing.T) {
 	var list builtList
 
+	last, hasLast := list.LastElement()
+
 	require.Equal(t, 0, len(list.OrderedList()))
 	require.False(t, list.Has("key"))
+	require.Equal(t, "", last)
+	require.False(t, hasLast)
 
-	newList := list.Add("a")
-	newList = newList.Add("b")
+	list = list.Add("a")
+	newList := list.Add("b")
 	newList = newList.Add("c")
+
+	last, hasLast = list.LastElement()
+
+	require.Equal(t, []string{"a"}, list.OrderedList())
+	require.True(t, list.Has("a"))
+	require.False(t, list.Has("b"))
+	require.False(t, list.Has("c"))
+	require.False(t, list.Has("d"))
+	require.Equal(t, "a", last)
+	require.True(t, hasLast)
+
+	last, hasLast = newList.LastElement()
 
 	require.Equal(t, []string{"a", "b", "c"}, newList.OrderedList())
 	require.True(t, newList.Has("a"))
 	require.True(t, newList.Has("b"))
 	require.True(t, newList.Has("c"))
 	require.False(t, newList.Has("d"))
+	require.Equal(t, "c", last)
+	require.True(t, hasLast)
+}
+
+func TestGraph(t *testing.T) {
+	tests := []struct {
+		descr       string
+		vertices    []string
+		edges       [][]string
+		expected    []string
+		expectedErr bool
+	}{
+		{
+			descr:    "test dag 1",
+			vertices: []string{},
+			edges: [][]string{
+				[]string{"X", "A"},
+				[]string{"X", "B"},
+				[]string{"Y", "A"},
+				[]string{"Y", "B"},
+				[]string{"A", "C"},
+			},
+			expected:    []string{"Y", "X", "B", "A", "C"},
+			expectedErr: false,
+		},
+		{
+			descr:    "test dag 2",
+			vertices: []string{"NOT LINKED"},
+			edges: [][]string{
+				[]string{"X", "A"},
+				[]string{"X", "B"},
+				[]string{"Y", "A"},
+				[]string{"Y", "B"},
+				[]string{"A", "C"},
+				[]string{"X", "A"}, // redeclared
+			},
+			expected:    []string{"Y", "X", "B", "A", "C", "NOT LINKED"},
+			expectedErr: false,
+		},
+		{
+			descr: "test dag 3",
+			edges: [][]string{
+				[]string{"5", "11"},
+				[]string{"7", "11"},
+				[]string{"7", "8"},
+				[]string{"3", "8"},
+				[]string{"3", "10"},
+				[]string{"11", "2"},
+				[]string{"11", "9"},
+				[]string{"11", "10"},
+				[]string{"8", "9"},
+			},
+			expected:    []string{"3", "7", "8", "5", "11", "10", "9", "2"},
+			expectedErr: false,
+		},
+		{
+			descr:    "test dag cycle",
+			vertices: []string{},
+			edges: [][]string{
+				[]string{"X", "A"},
+				[]string{"X", "B"},
+				[]string{"Y", "A"},
+				[]string{"Y", "B"},
+				[]string{"A", "C"},
+				[]string{"C", "X"},
+			},
+			expected:    []string{"X", "A", "B", "Y", "C"},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		g := newGraph()
+
+		for _, v := range test.vertices {
+			g.AddVertex(v)
+		}
+
+		for _, e := range test.edges {
+			g.AddEdge(e[0], e[1])
+		}
+
+		l, err := g.TopologicalOrdering()
+
+		if test.expectedErr {
+			require.NotNil(t, err, test.descr)
+		} else {
+			require.Nil(t, err, test.descr)
+		}
+
+		require.Equal(t, test.expected, l, test.descr)
+	}
 }
 
 func TestMultiErrBuilder(t *testing.T) {


### PR DESCRIPTION
The objects were closed in a random order. It was possible to have an
object with a closed dependency. It could lead to useless errors (and
error logs). In the worst case the dependency could be a logger and the
logs could be lost.

The objects are now closed in the right order. The dependencies are
closed after the objects using them.