### PR TITLE
Return detailed error (incl. stack trace) instead of `err.Error()` string

### DIFF
--- a/containerGetter.go
+++ b/containerGetter.go
@@ -152,7 +152,7 @@ func (g *containerGetter) formatCloseErr(err error) string {
 	if err == nil {
 		return ""
 	}
-	return " (with an error: " + err.Error() + ")"
+	return fmt.Sprintf(" (with an error: %+v)", err)
 }
 
 func (g *containerGetter) build(ctn *container, def Def, objKey objectKey) (obj interface{}, err error) {
@@ -168,7 +168,7 @@ func (g *containerGetter) build(ctn *container, def Def, objKey objectKey) (obj 
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("could not build `%s`: %s", def.Name, err.Error())
+		return nil, fmt.Errorf("could not build `%s`: %+v", def.Name, err)
 	}
 
 	return obj, nil

--- a/containerSlayer.go
+++ b/containerSlayer.go
@@ -102,7 +102,7 @@ func (s *containerSlayer) closeObject(obj interface{}, def Def) (err error) {
 	}
 
 	if err != nil {
-		return fmt.Errorf("could not close `%s`: %s", def.Name, err.Error())
+		return fmt.Errorf("could not close `%s`: %+v", def.Name, err)
 	}
 
 	return err

--- a/containerUnscopedGetter.go
+++ b/containerUnscopedGetter.go
@@ -48,7 +48,7 @@ func (g *containerUnscopedGetter) unscopedSafeGet(ctn *container, def Def) (inte
 
 	child, err := g.getUnscopedChild(ctn)
 	if err != nil {
-		return nil, fmt.Errorf("could not get `%s` because %s", def.Name, err.Error())
+		return nil, fmt.Errorf("could not get `%s` because %+v", def.Name, err)
 	}
 
 	return g.unscopedSafeGet(child, def)


### PR DESCRIPTION
In one of our projects, we are using the [`pkg/errors`](https://github.com/pkg/errors) library. Errors created with this library can contain a stack trace. Unfortunately, when returning such errors from our `build` functions, extra information like stack traces are currently *not* being printed out. 

With this change, errors created by `pkg/errors` are printed out in [extended format](https://pkg.go.dev/github.com/pkg/errors?utm_source=godoc#hdr-Formatted_printing_of_errors) (including stack trace). 

"Normal" errors created with `errros.New()` or `fmt.Errorf(...)` are not affected, the output for them stays the same.