### PR TITLE
Print panic return values incl. extra information

### DIFF
--- a/containerGetter.go
+++ b/containerGetter.go
@@ -158,7 +158,7 @@ func (g *containerGetter) formatCloseErr(err error) string {
 func (g *containerGetter) build(ctn *container, def Def, objKey objectKey) (obj interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("could not build `%s` because the build function panicked: %s", def.Name, r)
+			err = fmt.Errorf("could not build `%s` because the build function panicked: %+v", def.Name, r)
 		}
 	}()
 

--- a/containerSlayer.go
+++ b/containerSlayer.go
@@ -89,7 +89,7 @@ func (s *containerSlayer) removeChild(ctn *containerCore, child *containerCore) 
 func (s *containerSlayer) closeObject(obj interface{}, def Def) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("could not close `%s`, Close function panicked: %s", def.Name, r)
+			err = fmt.Errorf("could not close `%s`, Close function panicked: %+v", def.Name, r)
 		}
 	}()
 


### PR DESCRIPTION
Sorry to bug you again, but as a follow-up to #25, this also prints the return values from `panic` including extra information. 

This is useful when `panic` is called within a `build` function - with an error that has a stack trace, like the ones created by [pkg/errors](https://github.com/pkg/errors). With the changes from this PR, the output includes the stack trace, too 😊 